### PR TITLE
Adding rules to Java to ignore comment lines + bug fix in compileCommand option

### DIFF
--- a/universalmutator/analyze.py
+++ b/universalmutator/analyze.py
@@ -281,6 +281,8 @@ def main():
                     finally:
                         shutil.copy(src + ".um.backup", src)
                         os.remove(src + ".um.backup")
+                if os.path.exists(".um.mutant_output." + str(os.getpid())):
+                    os.remove(".um.mutant_output." + str(os.getpid()))
     print("=" * 80)
     print("MUTATION SCORE:", killCount / count)
 

--- a/universalmutator/static/java.rules
+++ b/universalmutator/static/java.rules
@@ -1,4 +1,7 @@
 (^\s*(@.+)) ==> DO_NOT_MUTATE
+(^\s*(\/\*.+)) ==> DO_NOT_MUTATE
+(^\s*(\/\/.+)) ==> DO_NOT_MUTATE
+(^\s*(\*.+)) ==> DO_NOT_MUTATE
 
 synchronized ==>
 


### PR DESCRIPTION
- Added 4 new rules to Java to ignore comments and annotations
- Updating code to cleanup um.output file generated by compileCommand option