### PR TITLE
fix file not found error

### DIFF
--- a/universalmutator/genmutants.py
+++ b/universalmutator/genmutants.py
@@ -424,14 +424,18 @@ def main():
                         checkLines.append(i)
                 for lineNo in checkLines:
                     fastCheckMutant = (lineNo, toGarbage(source[lineNo - 1]))
-                    mutator.makeMutant(source, fastCheckMutant, tmpMutantName)
+                    mutantMade = mutator.makeMutant(source, fastCheckMutant, tmpMutantName)
+                    if (not mutantMade):
+                        continue
                     fastCheckLine(mutant, source, sourceFile, uniqueMutants, compileFile, handler, deadCodeLines, interestingLines, tmpMutantName, lineNo)
                 if checkCombyDeadCode(deadCodeLines, mutant):
                     continue
             else:
                 if (mutant[0] not in interestingLines) and (mutant[0] not in deadCodeLines):
                     fastCheckMutant = (mutant[0], toGarbage(source[mutant[0] - 1]))
-                    mutator.makeMutant(source, fastCheckMutant, tmpMutantName)
+                    mutantMade = mutator.makeMutant(source, fastCheckMutant, tmpMutantName)
+                    if (not mutantMade):
+                        continue
                     fastCheckLine(mutant, source, sourceFile, uniqueMutants, compileFile, handler, deadCodeLines, interestingLines, tmpMutantName, mutant[0])
                 if mutant[0] in deadCodeLines:
                     continue


### PR DESCRIPTION
I was hitting the following error which popped up unreliably. It seems to depend more on the environment I was running `mutate` in rather than the specific `mutate` command/options I provided however I have not been able to isolate exactly what is triggering it.

```
Traceback (most recent call last):
  File "/Users/bohendo/.local/bin/mutate", line 8, in <module>
    sys.exit(main())
  File "/Users/bohendo/.local/pipx/venvs/universalmutator/lib/python3.10/site-packages/universalmutator/genmutants.py", line 436, in main
    fastCheckLine(mutant, source, sourceFile, uniqueMutants, compileFile, handler, deadCodeLines, interestingLines, tmpMutantName, mutant[0])
  File "/Users/bohendo/.local/pipx/venvs/universalmutator/lib/python3.10/site-packages/universalmutator/genmutants.py", line 31, in fastCheckLine
    mutantResult = handler(tmpMutantName, mutant, sourceFile, uniqueMutants)
  File "/Users/bohendo/.local/pipx/venvs/universalmutator/lib/python3.10/site-packages/universalmutator/solidity_handler.py", line 29, in handler
    shutil.copy(tmpMutantName, tmpMutantName + ".backup." + str(os.getpid()))
  File "/nix/store/ns32408gw33gfjvkgnrfbv2h3l0vnzd6-python3-3.10.8/lib/python3.10/shutil.py", line 417, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/nix/store/ns32408gw33gfjvkgnrfbv2h3l0vnzd6-python3-3.10.8/lib/python3.10/shutil.py", line 254, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '.tmp_mutant.41620.sol'
```

The change made by this PR fixes the error and `mutate` appears to run without issue now. However, I don't understand the internals well enough to assess whether or not this breaks some other functionality.