### PR TITLE
Proposed fix for Issue #22, create new directory if the directory passed into the --mutantDir flag does not exists.

### DIFF
--- a/tests/mutantDir_tests.py
+++ b/tests/mutantDir_tests.py
@@ -8,7 +8,7 @@ test_directory_name = "Test"
 
 # Utility functions to aid in testing
 def UtilRemoveTestingDir():
-    if(os.path.isdir("./"+test_directory_name)):
+    if os.path.isdir("./"+test_directory_name):
         shutil.rmtree("./"+test_directory_name)
 
 def UtilCreateTestingDir():

--- a/tests/mutantDir_tests.py
+++ b/tests/mutantDir_tests.py
@@ -16,7 +16,7 @@ def UtilCreateTestingDir():
         os.mkdir("./"+test_directory_name)
 
 # execute 'mutate ../examples/foo.py --mutantDir {test_directory_name}', returns true if no errors thrown, false otherwise
-def ExecuteMutateWithMutantDir(test_directory): 
+def ExecuteMutateWithMutantDir(test_directory):
     try:
         subprocess.run(["mutate", "../examples/foo.py", "--mutantDir", test_directory], check=True)
         return True
@@ -46,22 +46,22 @@ class TestMutantDir(unittest.TestCase):
         self.assertEqual(ExecuteMutateWithMutantDir(test_directory_name), True)
 
     # When the dir passed into mutantDir is multiple layers deep (./Parent/Child), and the parent directory does not exist, the program should exit with an error.
-    def test_mutantDir_FileNotFoundError(self): 
+    def test_mutantDir_FileNotFoundError(self):
         UtilRemoveTestingDir()
-        self.assertEqual(ExecuteMutateWithMutantDir(test_directory_name+"/Test2"), False) 
+        self.assertEqual(ExecuteMutateWithMutantDir(test_directory_name+"/Test2"), False)
 
     # When mutate does not have permissions to write into the file passed into --mutantDir, throw a PermissionError and exit.
-    def test_mutantDir_PermissionError(self): 
+    def test_mutantDir_PermissionError(self):
         UtilRemoveTestingDir()
         # Create Read Only Dir
         os.mkdir(test_directory_name+"ReadOnly")
         os.chmod(test_directory_name+"ReadOnly", stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
 
-        self.assertEqual(ExecuteMutateWithMutantDir(test_directory_name+"ReadOnly/Test"), False) 
+        self.assertEqual(ExecuteMutateWithMutantDir(test_directory_name+"ReadOnly/Test"), False)
 
         # Remove Read Only Dir
         os.rmdir(test_directory_name+"ReadOnly")
-    
+
     # When the dir passed into mutantDir does not exist, and the --legacyMutantDir flag is pressent, the program should crash
     def test_legacyMutantDir_DoesIgnoreCheck(self):
         UtilRemoveTestingDir()
@@ -82,4 +82,3 @@ if __name__ == '__main__':
 
     # Clean Testing Enviorment
     UtilRemoveTestingDir()
-

--- a/tests/mutantDir_tests.py
+++ b/tests/mutantDir_tests.py
@@ -1,0 +1,85 @@
+import unittest
+import subprocess
+import shutil
+import os
+import stat
+
+test_directory_name = "Test"
+
+# Utility functions to aid in testing
+def UtilRemoveTestingDir():
+    if(os.path.isdir("./"+test_directory_name)):
+        shutil.rmtree("./"+test_directory_name)
+
+def UtilCreateTestingDir():
+    if not os.path.isdir("./"+test_directory_name):
+        os.mkdir("./"+test_directory_name)
+
+# execute 'mutate ../examples/foo.py --mutantDir {test_directory_name}', returns true if no errors thrown, false otherwise
+def ExecuteMutateWithMutantDir(test_directory): 
+    try:
+        subprocess.run(["mutate", "../examples/foo.py", "--mutantDir", test_directory], check=True)
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"Error occurred: {e}")
+        return False
+
+# execute 'mutate ../examples/foo.py --mutantDir {test_directory_name} --legacyMutantDir', returns true if no errors thrown, false otherwise
+def ExecuteMutateWithMutantDirAndLegacyMutantDir(test_directory):
+    try:
+        subprocess.run(["mutate", "../examples/foo.py", "--mutantDir", test_directory, "--legacyMutantDir"], check=True)
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"Legacy Error occurred: {e}")
+        return False
+
+# Test Cases
+class TestMutantDir(unittest.TestCase):
+    # When the dir passed into mutantDir does not exist, the program should create a new one
+    def test_mutantDir_creatingNewDir(self):
+        UtilRemoveTestingDir()
+        self.assertEqual(ExecuteMutateWithMutantDir(test_directory_name), True)
+
+    # When the dir passed into mutantDir does exist, the program should NOT create a new one
+    def test_mutantDir_alreadyExistingDir(self):
+        UtilCreateTestingDir()
+        self.assertEqual(ExecuteMutateWithMutantDir(test_directory_name), True)
+
+    # When the dir passed into mutantDir is multiple layers deep (./Parent/Child), and the parent directory does not exist, the program should exit with an error.
+    def test_mutantDir_FileNotFoundError(self): 
+        UtilRemoveTestingDir()
+        self.assertEqual(ExecuteMutateWithMutantDir(test_directory_name+"/Test2"), False) 
+
+    # When mutate does not have permissions to write into the file passed into --mutantDir, throw a PermissionError and exit.
+    def test_mutantDir_PermissionError(self): 
+        UtilRemoveTestingDir()
+        # Create Read Only Dir
+        os.mkdir(test_directory_name+"ReadOnly")
+        os.chmod(test_directory_name+"ReadOnly", stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+
+        self.assertEqual(ExecuteMutateWithMutantDir(test_directory_name+"ReadOnly/Test"), False) 
+
+        # Remove Read Only Dir
+        os.rmdir(test_directory_name+"ReadOnly")
+    
+    # When the dir passed into mutantDir does not exist, and the --legacyMutantDir flag is pressent, the program should crash
+    def test_legacyMutantDir_DoesIgnoreCheck(self):
+        UtilRemoveTestingDir()
+        self.assertEqual(ExecuteMutateWithMutantDirAndLegacyMutantDir(test_directory_name), False)
+
+    # When the dir passed into mutantDir does exist, and the --legacyMutantDir flag is pressent, the program should execute normaly
+    def test_legactMutantDir_NoCrashWhenDirExists(self):
+        UtilCreateTestingDir()
+        self.assertEqual(ExecuteMutateWithMutantDirAndLegacyMutantDir(test_directory_name), True)
+
+
+if __name__ == '__main__':
+    # Clean Testing Enviorment
+    UtilRemoveTestingDir()
+
+    #Run Tests
+    unittest.main(exit=False)
+
+    # Clean Testing Enviorment
+    UtilRemoveTestingDir()
+

--- a/universalmutator/genmutants.py
+++ b/universalmutator/genmutants.py
@@ -257,16 +257,24 @@ def main():
         mdir = args[mdirpos + 1]
         args.remove("--mutantDir")
         args.remove(mdir)
-        
+
         mdirExists = os.path.isdir(mdir)
         if not mdirExists:
             print(f"THE DIRECTORY '{mdir}' PASSED INTO --mutantDir DID NOT EXIST, ATTEMPTING TO CREATE '{mdir}'")
             try:
-                os.mkdir(mdir);
+                os.mkdir(mdir)
                 print(f"DIRECTORY '{mdir}' WAS SUCCSESSFULLY CREATED")
-            except:
-                print(f"AN ERROR WAS THROWN WHILE ATTEMPTING TO CREATE '{mdir}'")
-                print(f"PLEASE CREATE THE DIRECTORY AND TRY AGAIN.")
+            except FileNotFoundError:
+                print(f"THE PARENT DIRECTORY FOR '{mdir}' WAS NOT FOUND. PLEASE CREATE IT AND TRY AGAIN.")
+                sys.exit(1)
+            except PermissionError:
+                print(f"ERROR CREATING '{mdir}', PERMISSION DENIED.")
+                sys.exit(1)
+            except OSError as error:
+                print(f"AN OS ERROR WAS THROWN WHILE ATTEMPTING TO CREATE '{mdir}': '{error}'")
+                sys.exit(1)
+            except Exception as error:
+                print(f"AN ERROR WAS THROWN WHILE ATTEMPTING TO CREATE '{mdir}': '{error}'")
                 sys.exit(1)
 
     if mdir[-1] != "/":
@@ -496,7 +504,7 @@ def main():
         if fuzz:
             mutantName = mdir + "fuzz.out"
         if (mutantResult == "VALID") or (mutantResult == "REDUNDANT" and redundantOK):
-            print("[written to", mutantName + "]", end=" ") 
+            print("[written to", mutantName + "]", end=" ")
 
             shutil.copy(tmpMutantName, mutantName)
             validMutants.append(mutant)

--- a/universalmutator/genmutants.py
+++ b/universalmutator/genmutants.py
@@ -118,7 +118,7 @@ def main():
         if len(sys.argv) < 2:
             print("ERROR: mutate requires at least one argument (a file to mutate)\n")
         print("USAGE: mutate <sourcefile> [<language>] [<rule1> <rule2>...]",
-              "[--noCheck] [--cmd <command string>] [--mutantDir <dir>]",
+              "[--noCheck] [--cmd <command string>] [--mutantDir <dir>] [--legacyMutantDir]",
               "[--lines <coverfile> [--tstl]] [--mutateTestCode] [--mutateBoth]",
               "[--ignore <file>] [--compile <file>] [--noFastCheck] [--swap]",
               "[--redundantOK] [--showRules] [--only <rule>]")

--- a/universalmutator/genmutants.py
+++ b/universalmutator/genmutants.py
@@ -203,6 +203,11 @@ def main():
         fuzz = True
         args.remove("--fuzz")
 
+    legacyMutantDir = False
+    if "--legacyMutantDir" in args:
+        legacyMutantDir = True
+        args.remove("--legacyMutantDir")
+
     printStat = False
     if "--printStat" in args:
         printStat = True
@@ -260,7 +265,7 @@ def main():
         args.remove(mdir)
 
         mdirExists = os.path.isdir(mdir)
-        if not mdirExists:
+        if not mdirExists and not legacyMutantDir:
             print(f"THE DIRECTORY '{mdir}' PASSED INTO --mutantDir DID NOT EXIST, ATTEMPTING TO CREATE '{mdir}'")
             try:
                 os.mkdir(mdir)

--- a/universalmutator/genmutants.py
+++ b/universalmutator/genmutants.py
@@ -126,7 +126,7 @@ def main():
         print("       --noCheck: skips compilation/comparison and just generates mutant files")
         print("       --cmd executes command string, replacing MUTANT with the mutant name, and uses return code")
         print("             to determine mutant validity")
-        print("       --mutantDir: directory to put generated mutants in; defaults to current directory")
+        print("       --mutantDir: directory to put generated mutants in, creates directory if it does not exist; defaults to current directory.")
         print("       --lines: only generate mutants for lines contained in <coverfile>")
         print("       --tstl: <coverfile> is TSTL output")
         print("       --mutateInStrings: mutate inside strings (not just turn to empty string)")
@@ -257,6 +257,18 @@ def main():
         mdir = args[mdirpos + 1]
         args.remove("--mutantDir")
         args.remove(mdir)
+        
+        mdirExists = os.path.isdir(mdir)
+        if not mdirExists:
+            print(f"THE DIRECTORY '{mdir}' PASSED INTO --mutantDir DID NOT EXIST, ATTEMPTING TO CREATE '{mdir}'")
+            try:
+                os.mkdir(mdir);
+                print(f"DIRECTORY '{mdir}' WAS SUCCSESSFULLY CREATED")
+            except:
+                print(f"AN ERROR WAS THROWN WHILE ATTEMPTING TO CREATE '{mdir}'")
+                print(f"PLEASE CREATE THE DIRECTORY AND TRY AGAIN.")
+                sys.exit(1)
+
     if mdir[-1] != "/":
         mdir += "/"
 
@@ -480,10 +492,12 @@ def main():
             mutantResult = handler(tmpMutantName, mutant, sourceFile, uniqueMutants, compileFile=compileFile)
         print(mutantResult, end=" ")
         mutantName = mdir + base + ".mutant." + str(mutantNo) + ending
+
         if fuzz:
             mutantName = mdir + "fuzz.out"
         if (mutantResult == "VALID") or (mutantResult == "REDUNDANT" and redundantOK):
-            print("[written to", mutantName + "]", end=" ")
+            print("[written to", mutantName + "]", end=" ") 
+
             shutil.copy(tmpMutantName, mutantName)
             validMutants.append(mutant)
             mutantNo += 1

--- a/universalmutator/genmutants.py
+++ b/universalmutator/genmutants.py
@@ -127,6 +127,7 @@ def main():
         print("       --cmd executes command string, replacing MUTANT with the mutant name, and uses return code")
         print("             to determine mutant validity")
         print("       --mutantDir: directory to put generated mutants in, creates directory if it does not exist; defaults to current directory.")
+        print("       --legacyMutantDir: simulates old mutantDir behavior; if the directory passed into --mutantDir does not exist, it will not be created and the progeam crashes.")
         print("       --lines: only generate mutants for lines contained in <coverfile>")
         print("       --tstl: <coverfile> is TSTL output")
         print("       --mutateInStrings: mutate inside strings (not just turn to empty string)")


### PR DESCRIPTION
## Changes in this PR

Given the discussion under Issue #22, this proposes a fix that will create the missing directory if the directory passed into the flag `--mutantDir` does not exist. The code changes proposed occur after the `--mutantDir` flag has been parsed in the `genmutants.py` file, where after the `--mutantDir` flag has been removed from the `args` list, the following is ran to ensure the directory is created safely.

```python
        mdirExists = os.path.isdir(mdir)
        if not mdirExists:
            print(f"THE DIRECTORY '{mdir}' PASSED INTO --mutantDir DID NOT EXIST, ATTEMPTING TO CREATE '{mdir}'")
            try:
                os.mkdir(mdir)
                print(f"DIRECTORY '{mdir}' WAS SUCCSESSFULLY CREATED")
            except FileNotFoundError:
                print(f"THE PARENT DIRECTORY FOR '{mdir}' WAS NOT FOUND. PLEASE CREATE IT AND TRY AGAIN.")
                sys.exit(1)
            except PermissionError:
                print(f"ERROR CREATING '{mdir}', PERMISSION DENIED.")
                sys.exit(1)
            except OSError as error:
                print(f"AN OS ERROR WAS THROWN WHILE ATTEMPTING TO CREATE '{mdir}': '{error}'")
                sys.exit(1)
            except Exception as error:
                print(f"AN ERROR WAS THROWN WHILE ATTEMPTING TO CREATE '{mdir}': '{error}'")
                sys.exit(1)
```

Should an exception be raised while creating the missing directory, the program exits a bit more gracefully, with an error printed for the user, without leading into a crash later on in the program.

Changes have be made to the documentation printed by the `--help` flag was changed to reflect this new behavior by `--mutantDir` as well. 

```
--mutantDir: directory to put generated mutants in, creates directory if it does not exist; defaults to current directory.
```

## Decisions made
 
It was ultimately decided that checking if the directory existed immediately after the the `--mutantDir` flag was parsed was the best place for this check to happen. Code below this point tends to assume that the directory passed into `--mutantDir` exists, but that false assumption is what caused the crash to occur in the first place. Adding the check and creation guard at the earliest possible point where it would make since to do so allows the code following the parsing of `--mutantDir` to operate in with this assumption safely.

## New Features

In issue #22, you made a point that users could be reliant on the previous behavior. To account for this, I've proposed a solution that adds a new flag named `--legacyMutantDir`. When this flag is used, the program skips checking to see of the directory passed into `--mutantDir` exists, therefore simulating the old `--mutantDir` behavior for users who might need it. 

This also includes the proper documentation printed by the `--help` flag to explain the use-case of `--legacyMutantDir`.

## Testing

The unit tests for this change can be found in `/tests/mutantDir_tests.py` and tests for the following:

 - If the directory passed into --mutantDir is created when it does not exists and the program is able to create it.
 - If the directory passed into --mutantDir does happen to already exist, does the program still run normally.
 - If the directory passed into --mutantDir contains a parent directory (./parent/child) and that parent does not exist, does the proper get error thrown and program exited.
 - If the directory passed into --mutantDir contains is read only, does the program throw the proper error and exit.
 - If --legacyMutantDir is passed into the program, and the directory passed into --mutantDir does not exist, does the program skip the checks added and crash like previously.
 - If --legacyMutantDir is passed into the program, and the directory passed into --mutantDir does exist, does the program run like normal and not crash.

Thank you for your time!

**This is a submission to the final project for CS386. Group: Ethan Heimer and Ryan Menaugh. No AI was used to generate any code, and all tests passed on MacOS.**

