### PR TITLE
Fix Python 3.12/pipx compatibility by replacing pkg_resources

### DIFF
--- a/universalmutator/mutator.py
+++ b/universalmutator/mutator.py
@@ -1,6 +1,9 @@
 from __future__ import print_function
 import re
-import pkg_resources
+try:
+    from importlib import resources as importlib_resources
+except ImportError:
+    import importlib_resources
 import random
 from comby import Comby
 import os
@@ -17,7 +20,13 @@ def parseRules(ruleFiles, comby=False):
                 rulePath = os.path.join('comby', ruleFile)
             else:
                 rulePath = os.path.join('static', ruleFile)
-            with pkg_resources.resource_stream('universalmutator', rulePath) as builtInRule:
+            #with pkg_resources.resource_stream('universalmutator', rulePath) as builtInRule:
+            #^^ change this line
+            resource = importlib_resources.files('universalmutator')
+            for part in rulePath.split(os.sep):
+                resource = resource.joinpath(part)
+
+            with resource.open('rb') as builtInRule:
                 for line in builtInRule:
                     line = line.decode()
                     rulesText.append((line, "builtin:" + ruleFile))


### PR DESCRIPTION
Replaced pkg_resources.resource_stream() with importlib.resources to support Python 3.12+ and pipx environments where pkg_resources may not be available.

Added compatibility import for older Python versions using importlib_resources fallback.

Tested by:
- running `python3 mutator.py --help`
- installing with `pip install .`
- running CLI: `mutate --help`

All functionality works as expected.