### PR TITLE
Keep non-ascii characters

### DIFF
--- a/universalmutator/genmutants.py
+++ b/universalmutator/genmutants.py
@@ -378,8 +378,11 @@ def main():
 
     with open(sourceFile, 'r') as file:
         for line in file:
-            # remove non-ascii characters (comby issue)
-            line_processed = line.encode('ascii', 'ignore').decode()
+            if comby:
+              # remove non-ascii characters (comby issue)
+              line_processed = line.encode('ascii', 'ignore').decode()
+            else:
+              line_processed = line
             source.append(line_processed)
 
     mutants = []


### PR DESCRIPTION
Currently, universalmutator removes non-ascii characters due to comby-related issues, even when comby mode is disabled. However, removing non-ascii characters can cause side effects. For example, Java code may no longer compile if a non-ascii character is removed and results in an empty character literal. This PR fixes the issue so that non-ascii characters are no longer removed when comby mode is not enabled.
